### PR TITLE
change free to open

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <body>
         <div class="row">
             <img alt="elementary OS" id="logotype" src="images/logotype.svg">
-            <h2>A fast and free replacement for Windows and OS X</h2>
+            <h2>A fast and open replacement for Windows and OS X</h2>
             <button id="download" class="suggested-action" onclick=window.open("http://downloads.sourceforge.net/project/elementaryos/unstable/elementaryos-unstable-amd64.20140810.iso")>Download Freya Beta 64bit</button>
         </div>
         <footer>


### PR DESCRIPTION
Seems kind of contradictory to say free when what we mean is libre, not gratis. Changed the wording to "open" instead of "free".