### PR TITLE
"amd64" becomes "AMD64" [See comment]

### DIFF
--- a/installation.php
+++ b/installation.php
@@ -12,7 +12,7 @@
                 <div class="column half">
                     <p>Minimum System Requirements:</p>
                     <ul>
-                        <li>1 GHz x86 or amd64 processor</li>
+                        <li>1 GHz x86 or AMD64 processor</li>
                         <li>512MB of system memory (RAM)</li>
                         <li>5GB of disk space</li>
                     </ul>
@@ -20,7 +20,7 @@
                 <div class="column half">
                     <p>Recommended System Requirements:</p>
                     <ul>
-                        <li>1 GHz x86 or amd64 processor</li>
+                        <li>1 GHz x86 or AMD64 processor</li>
                         <li>1GB of system memory (RAM)</li>
                         <li>15 GB of disk space</li>
                         <li>Internet access</li>


### PR DESCRIPTION
It's the correct spelling. However, the term "x86-64" is also commonly used (https://en.wikipedia.org/wiki/X86-64).