### PR TITLE
Adds classList support in IE<10 on install guide

### DIFF
--- a/installation.php
+++ b/installation.php
@@ -162,6 +162,7 @@
                 </div>
             </div>
 
+            <!--[if lt IE 10]><script type="text/javascript" src="https://cdn.jsdelivr.net/g/classlist"></script><![endif]-->
             <script type="text/javascript" src="scripts/installation.js"></script>
 <?php
     include '_templates/footer.html';


### PR DESCRIPTION
`classList` is not supported in IE < 10. This adds support for IE 8 and 9.