### PR TITLE
merge styles from get involved into main

### DIFF
--- a/get-involved.php
+++ b/get-involved.php
@@ -7,7 +7,7 @@
     include '_templates/header.php';
 ?>
             <section class="row hero">
-                <h2>Check out our progress for Freya Beta 2</h2>
+                <h1>Check out our progress for Freya Beta 2</h1>
 
                 <div class="charts">
                     <div class="barchart-ctn">
@@ -38,7 +38,7 @@
                     </div>
                 </div>
 
-                <h3>Contribute by doing these things</h3>
+                <h2>Contribute by doing these things</h2>
 
                 <div class="actions">
                     <a class="button flat" href="#translations">Translations</a>
@@ -51,14 +51,14 @@
             <section id="translations" class="light">
                 <div class="heading">
                     <div class="row">
-                        <h1><a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;A different language is a different vision of life.&rdquo; —Federico Fellini elementaryos.org/get-involved" target="_blank">&ldquo;A different language is a different vision of life.&rdquo;</a></h1>
+                        <q><a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;A different language is a different vision of life.&rdquo; —Federico Fellini elementaryos.org/get-involved" target="_blank">&ldquo;A different language is a different vision of life.&rdquo;</a></q>
                         <p class="small-label"><a href="https://en.wikipedia.org/wiki/Federico_Fellini" target="_blank">Federico Fellini</a></p>
                     </div>
                 </div>
 
                 <div class="row">
-                    <div class="column">
-                        <h2>Translations</h2>
+                    <div class="column half">
+                        <h1>Translations</h1>
                         <p>elementary OS is created and used by people from all around the World; help us make the experience even better by translating it into more languages. Launchpad has a built-in tool called Rosetta that enables collaborative translations online.</p>
 
                         <div class="actions">
@@ -66,7 +66,7 @@
                             <a class="button flat" href="https://help.launchpad.net/Translations" target="_blank">Get More Info About Rosetta</a>
                         </div>
                     </div>
-                    <div class="column">
+                    <div class="column half">
                         <img src="images/get-involved/translations.svg" alt="World map">
                     </div>
                 </div>
@@ -75,13 +75,13 @@
             <section id="web-development" class="dark">
                 <div class="heading">
                     <div class="row">
-                        <h1><a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;Websites should look good from the inside and out&rdquo; —Paul Cookson elementaryos.org/get-involved" target="_blank">&ldquo;Websites should look good from the inside and out&rdquo;</a></h1>
+                        <q><a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;Websites should look good from the inside and out&rdquo; —Paul Cookson elementaryos.org/get-involved" target="_blank">&ldquo;Websites should look good from the inside and out&rdquo;</a></q>
                         <p class="small-label"><a href="https://twitter.com/paulcookson" target="_blank">Paul Cookson</a></p>
                     </div>
                 </div>
 
                 <div class="web-browser">
-                    <h2>Web Development</h2>
+                    <h1>Web Development</h1>
                     <p>Our website is built using HTML, CSS, PHP and JavaScript. We're always looking for people experienced in those areas who would like to contribute and make it even better. Most of the design work is done by our Design Team, but we love design ideas and feedback for our Web Team.</p>
 
                     <div class="actions">
@@ -94,14 +94,14 @@
             <section id="design" class="light">
                 <div class="heading">
                     <div class="row">
-                        <h1><a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;Great design is making something memorable and meaningful.&rdquo; —Dieter Rams elementaryos.org/get-involved" target="_blank">&ldquo;Great design is making something memorable and meaningful.&rdquo;</a></h1>
+                        <q><a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;Great design is making something memorable and meaningful.&rdquo; —Dieter Rams elementaryos.org/get-involved" target="_blank">&ldquo;Great design is making something memorable and meaningful.&rdquo;</a></q>
                         <p class="small-label"><a href="https://en.wikipedia.org/wiki/Dieter_Rams" target="_blank">Dieter Rams</a></p>
                     </div>
                 </div>
 
                 <div class="row">
-                    <div class="column">
-                        <h2>Design</h2>
+                    <div class="column half">
+                        <h1>Design</h1>
                         <p>Every project begins with an idea. Our Design Team takes these and turns them into road maps. We break up design into two components:</p>
 
                         <p>
@@ -120,7 +120,7 @@
                             <a class="button flat" href="http://blog.elementaryos.org/post/107662321291/so-you-fancy-yourself-a-designer" target="_blank">Read About Our Workflow</a>
                         </div>
                     </div>
-                    <div class="column">
+                    <div class="column half">
                         <img src="images/get-involved/design.svg" alt="Application wire frame">
                     </div>
                 </div>
@@ -129,14 +129,14 @@
             <section id="desktop-development" class="dark">
                 <div class="heading">
                     <div class="row">
-                        <h1><a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;Before software can be reusable it first has to be usable&rdquo; —Ralph Johnson elementaryos.org/get-involved" target="_blank">&ldquo;Before software can be reusable it first has to be usable&rdquo;</a></h1>
+                        <q><a class="inline-tweet" href="http://twitter.com/home/?status=&ldquo;Before software can be reusable it first has to be usable&rdquo; —Ralph Johnson elementaryos.org/get-involved" target="_blank">&ldquo;Before software can be reusable it first has to be usable&rdquo;</a></q>
                         <p class="small-label"><a href="https://twitter.com/RalphJohnson" target="_blank">Ralph Johnson</a></p>
                     </div>
                 </div>
 
                 <div class="row">
-                    <div class="column">
-                        <h2>Desktop Development</h2>
+                    <div class="column half">
+                        <h1>Desktop Development</h1>
                         <p>Our desktop environment and all its apps are built using Vala, GTK+, Clutter, Cairo, Granite and a number of other free libraries. All of our code is hosted on Launchpad.net, a free service for open source projects. We're always looking for contributors of all skill levels.</p>
 
                         <div class="actions">
@@ -145,7 +145,7 @@
                             <a class="button flat" href="https://bugs.launchpad.net/elementary" target="_blank">See Our Open Bug Reports</a>
                         </div>
                     </div>
-                    <div class="column">
+                    <div class="column half">
                         <img src="images/get-involved/desktop-development.svg" alt="Scratch text editor">
                     </div>
                 </div>

--- a/styles/get-involved.css
+++ b/styles/get-involved.css
@@ -1,6 +1,7 @@
-html, body {
-	background-color: #3e4e54;
-	color: #c8d0d0;
+html,
+body {
+    background-color: #3e4e54;
+    color: #c8d0d0;
 }
 
 nav .logomark {
@@ -8,230 +9,216 @@ nav .logomark {
 }
 
 /* SECTIONS */
-section, section.hero {
-	padding-bottom: 100px;
-}
-section.light {
-	background-color: #fdf6e3;
-	color: #586e75;
-}
-section .heading {
-	background-color: rgba(0,0,0,0.04);
-}
-section .heading h1 {
-	font-weight: normal;
-	font-family: "Satisfy";
-	font-size: 36px;
-	margin-bottom: 10px;
-}
-@media (max-width: 414px) {
-	section .heading h1 {
-		font-size: 24px;
-	}
-}
-section .heading h1 a.inline-tweet:not(:hover) {
-	color: inherit;
-}
-section .heading p.small-label {
-	text-align: right;
-	font-size: 18px;
-}
-section .heading p.small-label a,
-section .heading p.small-label a:hover {
-	color: inherit;
-}
-section h2 {
-	font-weight: lighter;
-	font-size: 28px;
-}
-section > .row .column {
-	max-width: 576px;
-	text-align: left;
-	vertical-align: middle;
-}
-@media (max-width: 576px) {
-	section > .row .column {
-		max-width: 100%;
-	}
+section,
+section.hero {
+    padding-bottom: 96px;
 }
 
-/* BUTTONS */
+section.light {
+    background-color: #fdf6e3;
+    color: #586e75;
+}
+
+section .heading {
+    background-color: rgba(0,0,0,0.04);
+}
+
+section .heading p.small-label {
+    text-align: right;
+    font-size: 18px;
+}
+
+section .heading p.small-label a,
+section .heading p.small-label a:hover {
+    color: inherit;
+}
+
+.column.half {
+    text-align: left;
+    vertical-align: middle;
+}
+
+/*********
+* Button *
+*********/
+
 .button.flat {
-	display: block;
-	font-weight: bold;
-	background: none;
-	box-shadow: none;
-	text-shadow: none;
-	border-width: 2px;
-	padding: 7px;
-	margin-left: 0;
-	margin-top: 10px;
-	margin-bottom: 10px;
+    display: block;
+    font-weight: bold;
+    background: none;
+    box-shadow: none;
+    text-shadow: none;
+    border-width: 2px;
+    padding: 7px;
+    margin-left: 0;
+    margin-top: 10px;
+    margin-bottom: 10px;
 }
+
 .light .button.flat {
-	border-color: rgba(88, 110, 117, 0.5);
-	color: #586e75;
+    border-color: rgba(88, 110, 117, 0.5);
+    color: #586e75;
 }
+
 .dark .button.flat {
-	border-color: rgba(200, 208, 208, 0.5);
-	color: #c8d0d0;
+    border-color: rgba(200, 208, 208, 0.5);
+    color: #c8d0d0;
 }
+
 .button.flat.suggested-action {
-	color: white;
+    color: white;
 }
+
 section:nth-child(2) .button.flat.suggested-action {
-	background-color: #2aa198;
-	border-color: #2aa198;
+    background-color: #2aa198;
+    border-color: #2aa198;
 }
+
 section:nth-child(3) .button.flat.suggested-action {
-	background-color: #d53c12;
-	border-color: #d53c12;
+    background-color: #d53c12;
+    border-color: #d53c12;
 }
+
 section:nth-child(4) .button.flat.suggested-action {
-	background-color: #268bd2;
-	border-color: #268bd2;
+    background-color: #268bd2;
+    border-color: #268bd2;
 }
+
 section:nth-child(5) .button.flat.suggested-action {
-	background-color: #d33682;
-	border-color: #d33682;
+    background-color: #d33682;
+    border-color: #d33682;
 }
 
 @media (max-width: 1080px) {
-	.button.flat {
-		margin-left: auto;
-		margin-right: auto;
-	}
+    .button.flat {
+        margin-left: auto;
+        margin-right: auto;
+    }
 
-	.actions {
-		margin-bottom: 50px;
-	}
-}
-
-/* HERO */
-.row.hero h1,
-.row.hero h2,
-.row.hero h3 {
-	font-weight: lighter;
-}
-.row.hero h1 {
-	font-size: 64px;
-}
-.row.hero h2 {
-	font-size: 32px;
-}
-.row.hero h3 {
-	font-size: 28px;
+    .actions {
+        margin-bottom: 50px;
+    }
 }
 
 .charts .barchart-ctn {
-	width: 780px;
-	max-width: 100%;
+    width: 780px;
+    max-width: 100%;
 }
+
 .charts .barchart-ctn,
 .charts .doughnuts-ctn {
-	display: inline-block;
-	vertical-align: middle;
+    display: inline-block;
+    vertical-align: middle;
 }
+
 .charts .doughnuts-ctn {
-	margin-left: 30px;
+    margin-left: 30px;
 }
 .charts .doughnuts-ctn .doughnut {
-	position: relative;
-	width: 90px;
-	height: 90px;
-	margin: 15px;
+    position: relative;
+    width: 90px;
+    height: 90px;
+    margin: 15px;
 }
+
 .charts .doughnuts-ctn .doughnut canvas {
-	position: relative;
-	z-index: 1;
+    position: relative;
+    z-index: 1;
 }
+
 .doughnut .doughnut-label {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	padding: 11px 0;
-	font-size: 12px;
-	text-align: center;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 11px 0;
+    font-size: 12px;
+    text-align: center;
 }
+
 .doughnut .doughnut-count {
-	color: #93a1a1;
-	font-size: 28px;
+    color: #93a1a1;
+    font-size: 28px;
 }
+
 @media (max-width: 985px) {
-	.charts .doughnuts-ctn {
-		margin-left: 0;
-	}
-	.charts .doughnuts-ctn .doughnut {
-		display: inline-block;
-		margin: 4px;
-	}
+    .charts .doughnuts-ctn {
+        margin-left: 0;
+    }
+    .charts .doughnuts-ctn .doughnut {
+        display: inline-block;
+        margin: 4px;
+    }
 }
+
 @media (max-width: 360px) {
-	.charts .doughnuts-ctn .doughnut {
-		width: 70px;
-		height: 70px;
-	}
-	.charts .doughnuts-ctn .doughnut .doughnut-label {
-		padding: 4px 0;
-	}
+    .charts .doughnuts-ctn .doughnut {
+        width: 70px;
+        height: 70px;
+    }
+
+    .charts .doughnuts-ctn .doughnut .doughnut-label {
+        padding: 4px 0;
+    }
 }
+
 .doughnut.fix-committed .doughnut-count {
-	color: #95A5AC;
+    color: #95A5AC;
 }
+
 .doughnut.in-progress .doughnut-count {
-	color: #2aa198;
+    color: #2aa198;
 }
+
 .doughnut.created .doughnut-count {
-	color: #dc322f;
+    color: #dc322f;
 }
 
 .row.hero .actions .button.flat {
-	display: inline-block;
-	color: #c8d0d0;
-	border: 2px solid #c8d0d0;
-	border-radius: 4px;
-	min-width: 200px;
+    display: inline-block;
+    color: #c8d0d0;
+    border: 2px solid #c8d0d0;
+    border-radius: 4px;
+    min-width: 200px;
 }
+
 .row.hero .actions .button.flat:nth-child(1) {
-	border-color: #2aa198;
+    border-color: #2aa198;
 }
+
 .row.hero .actions .button.flat:nth-child(2) {
-	border-color: #cb4b16;
+    border-color: #cb4b16;
 }
+
 .row.hero .actions .button.flat:nth-child(3) {
-	border-color: #268bd2;
+    border-color: #268bd2;
 }
+
 .row.hero .actions .button.flat:nth-child(4) {
-	border-color: #d33682;
+    border-color: #d33682;
 }
 
 /* CUSTOM SECTIONS */
 .web-browser {
-	background-image: url("../images/get-involved/web-development.svg");
-	background-repeat: no-repeat;
-	background-position: top center;
-	width: 888px;
-	height: 444px;
-	max-width: 100%;
-	margin: 24px auto;
-	padding: 110px 190px;
-	text-align: left;
-	box-sizing: border-box;
+    background-image: url("../images/get-involved/web-development.svg");
+    background-repeat: no-repeat;
+    background-position: top center;
+    width: 888px;
+    height: 444px;
+    max-width: 100%;
+    margin: 24px auto;
+    padding: 110px 190px;
+    text-align: left;
+    box-sizing: border-box;
 }
 
 @media (max-width: 888px) {
-	.web-browser {
-		background-position: -2px 0;
-		width: 100%;
-		height: auto;
-		padding: 24px;
-		padding-top: 50px;
-		margin: 24px 0;
-	}
-}
-
-/* FOOTER */
-footer {
-	color: inherit;
+    .web-browser {
+        background-position: -2px 0;
+        width: 100%;
+        height: auto;
+        padding: 24px;
+        padding-top: 50px;
+        margin: 24px 0;
+    }
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -28,7 +28,6 @@ a:focus {
 
 h1 {
     font-size: 24px;
-    text-align: center;
     opacity: 0.8;
     font-weight: 600;
 }
@@ -52,6 +51,25 @@ p.small-label {
     font-size: 12px;
     opacity: 0.8;
     text-align: center;
+}
+
+q {
+    font-weight: 400;
+    font-family: "Satisfy";
+    font-size: 36px;
+    margin-bottom: 10px;
+}
+
+
+q:before,
+q:after {
+    content: none;
+}
+
+@media (max-width: 414px) {
+    q {
+        font-size: 24px;
+    }
 }
 
 kbd {
@@ -87,9 +105,8 @@ img.hero {
 }
 
 .inline-tweet {
-    color: #333;
+    color: inherit;
 }
-
 
 .inline-tweet:focus,
 .inline-tweet:hover {
@@ -206,7 +223,8 @@ nav .logomark {
 footer {
     text-align: center;
     font-size: 12px;
-    color: #666;
+    color: inherit;
+    opacity: 0.8;
 }
 
 footer ul {
@@ -268,6 +286,12 @@ footer ul li a:focus i.fa {
 
 .column.third p {
     text-align: center;
+}
+
+.column img {
+    margin-left: auto;
+    margin-right: auto;
+    display: block;
 }
 
 .row {


### PR DESCRIPTION
This branch tries to reduce the size of get-involved.css by merging styles into main.css and removing obsolete and redundant styles. It also tries to fix some code-style blunders like spaces instead of tabs, new lines after selectors, etc.

Watch out for regressions in the alignment/resizing of columns and their contents on desktop and mobile. Also check to make sure regressions weren't introduced to header styles on the homepage and installation page.

fixes #255 