### PR TITLE
Remove amount selection after payment, fixing #339

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,25 +15,27 @@
             </div>
             <img class="hero" src="images/notebook.png">
             <div class="row">
-                <?php
-                    if ( isset($_COOKIE['has_paid_freya']) && $_COOKIE['has_paid_freya'] ) {
-                        ?>
-                <input type="hidden" id="amount-twenty-five" value="0">
-                        <?php
-                    } else {
-                        ?>
-                <button id="amount-ten" value="10" class="small-button payment-button target-amount">10</button>
-                <button id="amount-twenty-five" value="25" class="small-button payment-button target-amount checked">25</button>
-                <button id="amount-fifty" value="50" class="small-button payment-button target-amount">50</button>
-                <div class="column">
-                    <sup class="pre-amount">$</sup>
-                    <input type="number" step="0.01" min="0" max="999999.99" id="amount-custom" class="button small-button target-amount" placeholder="Custom">
-                    <p class="small-label focus-reveal text-center">Enter any dollar amount.</p>
+                <div id="amounts">
+                    <?php
+                        if ( isset($_COOKIE['has_paid_freya']) && $_COOKIE['has_paid_freya'] ) {
+                            ?>
+                    <input type="hidden" id="amount-twenty-five" value="0">
+                            <?php
+                        } else {
+                            ?>
+                    <button id="amount-ten" value="10" class="small-button payment-button target-amount">10</button>
+                    <button id="amount-twenty-five" value="25" class="small-button payment-button target-amount checked">25</button>
+                    <button id="amount-fifty" value="50" class="small-button payment-button target-amount">50</button>
+                    <div class="column">
+                        <sup class="pre-amount">$</sup>
+                        <input type="number" step="0.01" min="0" max="999999.99" id="amount-custom" class="button small-button target-amount" placeholder="Custom">
+                        <p class="small-label focus-reveal text-center">Enter any dollar amount.</p>
+                    </div>
+                    <div style="clear:both;"></div>
+                            <?php
+                        }
+                    ?>
                 </div>
-                <div style="clear:both;"></div>
-                        <?php
-                    }
-                ?>
                 <button type="submit" id="download" class="suggested-action">Download Freya Beta</button>
                 <p class="small-label">886.0 MB (for PC or Mac)</p>
             </div>

--- a/scripts/homepage.js
+++ b/scripts/homepage.js
@@ -54,6 +54,11 @@ function do_stripe_payment (amount) {
             console.log(token);
             process_payment(amount, token);
             open_download_overlay();
+
+            if ($('#amount-twenty-five').val() !== 0) {
+                $('#amounts').html('<input type="hidden" id="amount-twenty-five" value="0">');
+                $('#amount-twenty-five').each(amountClick);
+            }
         },
         name: 'elementary LLC.',
         description: 'elementary OS download',


### PR DESCRIPTION
This should fix it. Could use a review. Hope the style is okay.

All I did in index.php was add `<div class="amounts"> ... </div>` plus an indentation, hence the unnecessarily long diff.

I'm fairly sure it'll work in theory, but I don't have a spare stripe API key sitting around.

Relevant: Would it be possible/safe to put a stripe test key in this repo?