### PR TITLE
Correct name for Serbian; Add Serbian Ijekavian

### DIFF
--- a/_templates/l10n.php
+++ b/_templates/l10n.php
@@ -18,7 +18,7 @@ function list_langs() {
         'ro_RO' => 'Română',
         'ru' => 'Русский',
         'sr' => 'Српски',
-        'sr@Ijekavian' => 'Српски (ијекавица)'
+        'sr@Ijekavian' => 'Српски (ијекавица)',
         'tr_TR' => 'Türkçe',
         'uk' => 'Мова',
         'zh_CN' => '國語'

--- a/_templates/l10n.php
+++ b/_templates/l10n.php
@@ -17,7 +17,8 @@ function list_langs() {
         'pt_PT' => 'Português',
         'ro_RO' => 'Română',
         'ru' => 'Русский',
-        'sr' => 'Српски, Srpski',
+        'sr' => 'Српски',
+        'sr@Ijekavian' => 'Српски (ијекавица)'
         'tr_TR' => 'Türkçe',
         'uk' => 'Мова',
         'zh_CN' => '國語'


### PR DESCRIPTION
Serbian language name is currently written as 'Српски, Srpski', which is imprecise. Proper localized language name is 'Српски'.
Translation in Ijekavian dialect of Serbian language is completed, so this item should be added to the list.