### PR TITLE
Stripe Email Receipts

### DIFF
--- a/backend/payment.php
+++ b/backend/payment.php
@@ -1,9 +1,9 @@
 <?php
 require_once('./lib/Stripe.php');
 // for MASTER
-// require_once('./config.php');
+require_once('./config.php');
 // for Branches
-require_once('../../../backend/config.php');
+// require_once('../../../backend/config.php');
 
 Stripe::setApiKey($config['stripe_sk']);
 

--- a/backend/payment.php
+++ b/backend/payment.php
@@ -1,6 +1,9 @@
 <?php
 require_once('./lib/Stripe.php');
-require_once('./config.php');
+// for MASTER
+// require_once('./config.php');
+// for Branches
+require_once('../../../backend/config.php');
 
 Stripe::setApiKey($config['stripe_sk']);
 
@@ -8,6 +11,7 @@ Stripe::setApiKey($config['stripe_sk']);
 if (isset($_POST['token'])) {
     $token  = $_POST['token'];
     $amount = $_POST['amount'];
+    $email = $_POST['email'];
 
     // Create the charge on Stripe's servers - this will charge the user's card
     try {
@@ -15,14 +19,15 @@ if (isset($_POST['token'])) {
             'amount' => $amount,
             'currency' => 'usd',
             'card' => $token,
-            'description' => 'elementary OS download')
-        );
+            'description' => 'elementary OS download',
+            'receipt_email' => $email,
+        ));
         // Set an insecure, HTTP only cookie for 10 years in the future.
-        setcookie('has_paid_freya', $amount, time()+315360000, '/', '.elementary.io', 0, 1);
+        setcookie('has_paid_freya', $amount, time() + 315360000, '/', '.elementary.io', 0, 1);
         echo 'OK';
     } catch(Stripe_CardError $e) {
         echo 'error';
     }
-} else { 
+} else {
     echo $config['stripe_pk'];
 }

--- a/backend/payment.php
+++ b/backend/payment.php
@@ -1,9 +1,12 @@
 <?php
 require_once('./lib/Stripe.php');
-// for MASTER
-require_once('./config.php');
-// for Branches
-// require_once('../../../backend/config.php');
+if ( substr($_SERVER['REQUEST_URI'], 0, 8) == '/branch/' ) {
+    // for Branches
+    require_once('../../../backend/config.php');
+} else {
+    // for MASTER
+    require_once('./config.php');
+}
 
 Stripe::setApiKey($config['stripe_sk']);
 

--- a/scripts/homepage.js
+++ b/scripts/homepage.js
@@ -52,7 +52,7 @@
         StripeCheckout.open({
             key: stripe_key,
             token: function (token) {
-                console.log(token);
+                console.log(JSON.parse(JSON.stringify(token)));
                 process_payment(amount, token);
                 open_download_overlay();
             },
@@ -75,7 +75,7 @@
         payment_http = new XMLHttpRequest();
         payment_http.open('POST','./backend/payment.php',true);
         payment_http.setRequestHeader('Content-type','application/x-www-form-urlencoded');
-        payment_http.send('amount=' + amount + '&token=' + token.id);
+        payment_http.send('amount=' + amount + '&token=' + token.id + '&email=' + encodeURIComponent(token.email));
     }
 
     function open_download_overlay () {


### PR DESCRIPTION
**Pass using proper variable names, add config for testing branches too.**

Unlike funnylookinhat's branch, this encodes the email for submission and fixes a related cookie issue.

_This is a new branch because my previous branch had fallen too far out of sync with master, and I the rebase was very messy._

**Testable at http://beta.elementary.io/branch/stripe-receipts-3**

### Proof
![screenshot from 2015-04-01 14 48 38](https://cloud.githubusercontent.com/assets/831389/6942249/395eef4a-d87e-11e4-8e05-cf0b3b177776.png)