### PR TITLE
Fixes install instructions platform autodetection

### DIFF
--- a/scripts/installation.js
+++ b/scripts/installation.js
@@ -163,8 +163,8 @@
     }
 
     if (currentOs == 'osx') {
-        selectChoice('booting-choices', 'booting-on-a-pc');
-    } else {
         selectChoice('booting-choices', 'booting-on-a-mac');
+    } else {
+        selectChoice('booting-choices', 'booting-on-a-pc');
     }
 })();


### PR DESCRIPTION
Windows was shown if a Mac was detected and vice-versa.