### PR TITLE
Update learning-the-basics.md

### DIFF
--- a/docs/learning-the-basics.md
+++ b/docs/learning-the-basics.md
@@ -48,7 +48,7 @@ You can customize the dock's behavior through **[System Settings](/docs/learning
 <div class="clear row" markdown="1">
 <div class="column half" markdown="1">
 
-App's exist in their own windows which can be closed, maximized, or moved around.
+Apps exist in their own windows which can be closed, maximized, or moved around.
 
 When you open an app, its window appears on the desktop. Each app typically has three areas: the window buttons, a toolbar, and the contents of the app.
 


### PR DESCRIPTION
Fixes typo reported here: https://www.transifex.com/projects/p/elementary-mvp/translate/#es/docs_learning-the-basics/44681082

> TYPO! There is an extraneous apostrophe in the first word. You do not pluralize like that. »’s« is used only to express the possessive.