### PR TITLE
Fixes wrong l10n links

### DIFF
--- a/_templates/footer.php
+++ b/_templates/footer.php
@@ -13,7 +13,7 @@ set_l10n_domain('layout');
                     <ul>
                     <?php
                     foreach (list_langs() as $langCode => $langName) {
-                        $path = $sitewide['root'].$langCode.(($page['name'] == 'index') ? '' : $page['path']);
+                        $path = $sitewide['root'].$langCode.$page['path'];
                         ?>
                         <li><a href="<?php echo $path; ?>" rel="alternate" hreflang="<?php echo str_replace('_', '-', $langCode); ?>" data-l10n-off>
                             <?php echo $langName; ?>

--- a/_templates/l10n.php
+++ b/_templates/l10n.php
@@ -356,10 +356,7 @@ function init_l10n() {
         && $page['lang'] != 'en') {
 
         $url = $sitewide['root'];
-        $url .= $page['lang'];
-        if ($page['name'] != 'index') {
-            $url .= $page['path'];
-        }
+        $url .= $page['lang'].$page['path'];
         $url = '/'.ltrim($url, '/'); // Make sure there is a / at the begining
         header('Location: '.$url);
         exit();


### PR DESCRIPTION
On homepage, language links are `/en` instead of `/en/`. Thus, a 404 page is returned.