### PR TITLE
Logotype Include (Fixes #338)

### DIFF
--- a/index.php
+++ b/index.php
@@ -10,7 +10,6 @@
             </script>
 
             <div class="row">
-                <object data="images/logotype.svg" type="image/svg+xml" id="logotype" data-l10n-off>elementary OS</object>
                 
                 <?php
                     // Embed the SVG to fix scaling in WebKit 1.x,

--- a/index.php
+++ b/index.php
@@ -11,6 +11,13 @@
 
             <div class="row">
                 <object data="images/logotype.svg" type="image/svg+xml" id="logotype" data-l10n-off>elementary OS</object>
+                
+                <?php
+                    // Embed the SVG to fix scaling in WebKit 1.x,
+                    // while preserving CSS options for the image.
+                    include('images/logotype.svg');
+                ?>
+                
                 <h4>A fast and open replacement for Windows and OS X</h4>
             </div>
             <img class="hero" src="images/notebook.png">

--- a/index.php
+++ b/index.php
@@ -10,16 +10,20 @@
             </script>
 
             <div class="row">
+                <div id="logotype">
                 
-                <?php
-                    // Embed the SVG to fix scaling in WebKit 1.x,
-                    // while preserving CSS options for the image.
-                    include('images/logotype.svg');
-                ?>
-                
+                    <?php
+                        // Embed the SVG to fix scaling in WebKit 1.x,
+                        // while preserving CSS options for the image.
+                        include('images/logotype.svg');
+                    ?>
+                    
+                </div>
                 <h4>A fast and open replacement for Windows and OS X</h4>
             </div>
+            
             <img class="hero" src="images/notebook.png">
+            
             <div class="row">
                 <div id="amounts">
                     <?php

--- a/styles/main.css
+++ b/styles/main.css
@@ -555,7 +555,7 @@ button.suggested-action,
     height: 66px;
     width: 454px;
     max-width: 80%;
-    margin: 0 auto;
+    margin: 16px auto;
 }
 #logotype svg {
     position: absolute;
@@ -565,6 +565,7 @@ button.suggested-action,
     left: 0;
     right: 0;
     bottom: 0;
+    overflow: visible;
 }
 /*
 #logotype svg path {

--- a/styles/main.css
+++ b/styles/main.css
@@ -553,6 +553,7 @@ button.suggested-action,
 #logotype {
     max-width: 100%;
     width: 454px;
+    margin: 0 auto;
 }
 
 .small-button {

--- a/styles/main.css
+++ b/styles/main.css
@@ -566,9 +566,11 @@ button.suggested-action,
     right: 0;
     bottom: 0;
 }
+/*
 #logotype svg path {
     fill: red;
 }
+*/
 
 .small-button {
     margin: 3px;

--- a/styles/main.css
+++ b/styles/main.css
@@ -551,9 +551,23 @@ button.suggested-action,
 }
 
 #logotype {
-    max-width: 100%;
+    position: relative;
+    height: 66px;
     width: 454px;
+    max-width: 80%;
     margin: 0 auto;
+}
+#logotype svg {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+#logotype svg path {
+    fill: red;
 }
 
 .small-button {


### PR DESCRIPTION
* Remove LogoType object.
* Add LogoType PHP include.
* Add boundary box.
* Add margin to center boundary.
* Fix #338
* Fix resulting issue with 1px overflow being cut off.
* Fix nav bar coming too close when on mobile.

#### Testing

Testing in Midori on Luna to check the original height issue is fixed.http://beta.elementary.io/branch/logotype-include/

#### Notes

Without a proper `img` tag, CSS styling is not inherited, but can be set to the `path` directly, like so:
```
#logotype svg path {
    fill: red;
}
```