### PR TITLE
Fix Chinese languages' names

### DIFF
--- a/_templates/l10n.php
+++ b/_templates/l10n.php
@@ -32,8 +32,8 @@ function list_langs() {
         'sv' => 'Svenska',
         'tr_TR' => 'Türkçe',
         'uk' => 'Мова',
-        'zh_CN' => '國語',
-        'zh_TW' => '台湾',
+        'zh_CN' => '简体中文',
+        'zh_TW' => '繁體中文',
     );
 }
 


### PR DESCRIPTION
Changed from vague meanings of "Mandarin" and "Taiwan" to "Simplified Chinese" and "Traditional Chinese". Both mainland China & Taiwan speak mandarin, and also "mandarin" was written in traditional chinese while taking you to the simplified chinese page, and "taiwan" was written in simplified chinese but takes you to the traditional chinese page. By changing them to "Simplified Chinese" written in simplified chinese and "Traditional Chinese" written in traditional chinese, it fixes the problem and makes it clearer which variety of chinese it is.