### PR TITLE
Fixes issues with <br> and l10n

### DIFF
--- a/_templates/l10n.php
+++ b/_templates/l10n.php
@@ -235,11 +235,14 @@ function translate_html($input, $translate = 'translate') {
                             break;
                         }
                     }
-                    if ($j < strlen($attrs)) { // Broke inside the loop, append the remaining chars
+                    if ($j < strlen($attrs)) {
+                        // Broke inside the loop, append the remaining chars
                         $tag .= substr($attrs, $j);
                     }
                 }
-            } else { // No attributes in this tag
+            } elseif (rtrim($tag, '/ ') != 'br') {
+                // No attributes in this tag
+                // Set current tag, if not a line break
                 $tagName = $tag;
             }
 


### PR DESCRIPTION
Translation strings were split when a `<p>` contains `<br>` and `<a>`.

See https://www.transifex.com/projects/p/elementary-mvp/translate/#es/get-involved/40056505