### PR TITLE
Enable SSL when available using an asynchronous HSTS header. Fixes #258

### DIFF
--- a/_templates/header.php
+++ b/_templates/header.php
@@ -80,7 +80,7 @@ begin_html_l10n();
         
         <script>
             (function(d,s,f){g=d.createElement(s),u=d.getElementsByTagName(s)[0],g.async=1,g.src=f,u.parentNode.insertBefore(g,u)})
-        	(document,'script','https://beta.elementary.io/branch/hsts-conditional/backend/hsts.php')
+            (document,'script','https://beta.elementary.io/branch/hsts-conditional/backend/hsts.php')
         </script>
 
         <script>

--- a/_templates/header.php
+++ b/_templates/header.php
@@ -77,6 +77,11 @@ begin_html_l10n();
         <link rel="stylesheet" type="text/css" media="all" href="https://fonts.googleapis.com/css?family=Raleway:100|Open+Sans:300,400,600|Droid+Sans+Mono">
         <link rel="stylesheet" type="text/css" media="all" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css">
         <link rel="stylesheet" type="text/css" media="all" href="styles/main.css">
+        
+        <script>
+            (function(d,s,f){g=d.createElement(s),u=d.getElementsByTagName(s)[0],g.async=1,g.src=f,u.parentNode.insertBefore(g,u)})
+        	(document,'script','https://beta.elementary.io/branch/hsts-conditional/backend/hsts.php')
+        </script>
 
         <script>
             <?php include __DIR__.'/../scripts/jql.min.js'; ?>

--- a/_templates/header.php
+++ b/_templates/header.php
@@ -80,7 +80,7 @@ begin_html_l10n();
         
         <script>
             (function(d,s,f){g=d.createElement(s),u=d.getElementsByTagName(s)[0],g.async=1,g.src=f,u.parentNode.insertBefore(g,u)})
-            (document,'script','https://beta.elementary.io/branch/hsts-conditional/backend/hsts.php')
+            (document,'script','https:<?php echo $sitewide['branch_root']; ?>backend/hsts.php')
         </script>
 
         <script>

--- a/_templates/sitewide.php
+++ b/_templates/sitewide.php
@@ -1,9 +1,5 @@
 <?php
 
-ini_set('display_errors',1);
-ini_set('display_startup_errors',1);
-error_reporting(-1);
-
 // Honor the IE do-not-track-header,
 // even though it's set automatically.
 $respectIE = true;

--- a/_templates/sitewide.php
+++ b/_templates/sitewide.php
@@ -1,12 +1,16 @@
 <?php
 
+ini_set('display_errors',1);
+ini_set('display_startup_errors',1);
+error_reporting(-1);
+
 // Honor the IE do-not-track-header,
 // even though it's set automatically.
 $respectIE = true;
 // Set the DNT variables.
 include __DIR__.'/../backend/here-miss.php';
 
-include_once __DIR__.'/../backend/function.branchname.php';
+include __DIR__.'/../backend/function.branchname.php';
 $sitewide['branch_root'] = branch_name();
 
 date_default_timezone_set('UTC');

--- a/_templates/sitewide.php
+++ b/_templates/sitewide.php
@@ -6,6 +6,9 @@ $respectIE = true;
 // Set the DNT variables.
 include __DIR__.'/../backend/here-miss.php';
 
+include_once __DIR__.'/../backend/function.branchname.php';
+$sitewide['branch_root'] = branch_name();
+
 date_default_timezone_set('UTC');
 
 $sitewide['title'] = 'elementary';

--- a/backend/function.branchname.php
+++ b/backend/function.branchname.php
@@ -1,5 +1,5 @@
 <?php
-function branch_root() {
+function branch_name() {
     $Branch = '//'.filter_input(INPUT_SERVER, 'HTTP_HOST').'/';
     $Request_URI = filter_input(INPUT_SERVER, 'REQUEST_URI');
     $Request_URI = explode('/', $Request_URI);

--- a/backend/function.branchname.php
+++ b/backend/function.branchname.php
@@ -4,7 +4,7 @@ function branch_root() {
     $Request_URI = explode('/', $Request_URI);
     var_dump($Request_URI);
     if ( $Request_URI[1] == 'branch' ) {
-        $Branch = Request_URI[3];
+        $Branch = $Request_URI[3];
     } else {
         $Branch = false;
     }

--- a/backend/function.branchname.php
+++ b/backend/function.branchname.php
@@ -3,11 +3,8 @@ function branch_root() {
     $Branch = '//'.filter_input(INPUT_SERVER, 'HTTP_HOST').'/';
     $Request_URI = filter_input(INPUT_SERVER, 'REQUEST_URI');
     $Request_URI = explode('/', $Request_URI);
-    var_dump($Request_URI);
     if ( $Request_URI[1] == 'branch' ) {
         $Branch .= 'branch/'.$Request_URI[2];
     }
     return $Branch;
 }
-
-echo branch_root();

--- a/backend/function.branchname.php
+++ b/backend/function.branchname.php
@@ -1,0 +1,14 @@
+<?php
+function branch_root() {
+    $Request_URI = filter_input(INPUT_SERVER, 'REQUEST_URI');
+    $Request_URI = explode('/', $Request_URI);
+    var_dump($Request_URI);
+    if ( $Request_URI[1] == 'branch' ) {
+        $Branch = Request_URI[3];
+    } else {
+        $Branch = false;
+    }
+    return '//'.filter_input(INPUT_SERVER, 'HTTP_HOST').'/'.$Branch;
+}
+
+echo branch_root();

--- a/backend/function.branchname.php
+++ b/backend/function.branchname.php
@@ -1,14 +1,13 @@
 <?php
 function branch_root() {
+    $Branch = '//'.filter_input(INPUT_SERVER, 'HTTP_HOST').'/';
     $Request_URI = filter_input(INPUT_SERVER, 'REQUEST_URI');
     $Request_URI = explode('/', $Request_URI);
     var_dump($Request_URI);
     if ( $Request_URI[1] == 'branch' ) {
-        $Branch = $Request_URI[3];
-    } else {
-        $Branch = false;
+        $Branch .= 'branch/'.$Request_URI[2];
     }
-    return '//'.filter_input(INPUT_SERVER, 'HTTP_HOST').'/'.$Branch;
+    return $Branch;
 }
 
 echo branch_root();

--- a/backend/function.branchname.php
+++ b/backend/function.branchname.php
@@ -4,7 +4,7 @@ function branch_name() {
     $Request_URI = filter_input(INPUT_SERVER, 'REQUEST_URI');
     $Request_URI = explode('/', $Request_URI);
     if ( $Request_URI[1] == 'branch' ) {
-        $Branch .= 'branch/'.$Request_URI[2];
+        $Branch .= 'branch/'.$Request_URI[2].'/';
     }
     return $Branch;
 }

--- a/backend/hsts.php
+++ b/backend/hsts.php
@@ -1,0 +1,17 @@
+<?php
+
+header('strict-transport-security: max-age=31536000;');
+
+// WARNING:
+// Do NOT use "includeSubDomains"
+// We have insecure sub-domains
+
+// "preload" would not do anything as we don't meet the requirements
+// https://hstspreload.appspot.com/
+
+// Compatibility
+// http://caniuse.com/#feat=stricttransportsecurity
+
+// We're going to pretend this is JavaScript, so we can log something.
+header('Content-Type: application/javascript');
+?>console.log('HSTS Loaded');

--- a/backend/hsts.php
+++ b/backend/hsts.php
@@ -12,6 +12,5 @@ header('strict-transport-security: max-age=31536000;');
 // Compatibility
 // http://caniuse.com/#feat=stricttransportsecurity
 
-// We're going to pretend this is JavaScript, so we can log something.
-header('Content-Type: application/javascript');
-?>console.log('HSTS Loaded');
+// No content, send only this.
+header($_SERVER['SERVER_PROTOCOL'].' 204 No Content');


### PR DESCRIPTION
Loading http://beta.elementary.io/branch/hsts-conditional/ will attempt to load a fixed, secure resource. This will enable HTTPS on all subsequent requests if available, or fail if not.