### PR TITLE
Prevent scrolling behind language popover

### DIFF
--- a/scripts/popover.js
+++ b/scripts/popover.js
@@ -23,4 +23,15 @@ $(function () {
 			$popover.removeClass('active');
 		});
 	});
+
+	// Prevent scrolling behind popover
+	$('.popover').hover(
+		function() {
+			$('body').css('pointer-events', 'none');
+			$(this).css('pointer-events', 'all');
+		}, function() {
+			$('body').css('pointer-events', '');
+			$(this).css('pointer-events', '');
+		}
+	);
 });


### PR DESCRIPTION
Fixes #533

This implementation uses pointer events. See browser compatibility here: http://caniuse.com/#feat=pointer-events

When the popover is moused over, it disables scrolling for the body and enables it only for the popover. When the pop over is moused out, the original settings are restored.