### PR TITLE
Fixes newline in CloudeFlare's e-mail protection scripts

### DIFF
--- a/scripts/docs/main.js
+++ b/scripts/docs/main.js
@@ -1,7 +1,9 @@
 $(document).ready(function() {
     $('pre code').each(function(i, block) {
-        // Highlight code block
-        hljs.highlightBlock(block);
+        // Remove newline from CloudFlare's e-mail protection script
+        $(this).find('script').each(function () {
+            $(this).text($(this).text().trim());
+        });
 
         // Add line numbers
         var lines = $(this).text().trim().split('\n').length;
@@ -11,5 +13,8 @@ $(document).ready(function() {
         for (var i = 1; i <= lines; i++){
             $numbering.append($('<li/>').text(i));
         }
+
+        // Highlight code block
+        hljs.highlightBlock(block);
     });
 });


### PR DESCRIPTION
Newlines break line numbering in code blocks.

Fixes #522 