### PR TITLE
Add sane max row width for docs

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -484,6 +484,10 @@ footer ul li a:focus {
     text-align: center;
 }
 
+.row.docs {
+  max-width: 800px;
+}
+
 .row .row {
     padding: 24px 0;
 }


### PR DESCRIPTION
What it says on the tin. Max row width for documentation is pretty cray right now. This sets a much more sane max-width that should make it a lot easier to read.