### PR TITLE
Adds more ignored tags to l10n

### DIFF
--- a/_templates/l10n.php
+++ b/_templates/l10n.php
@@ -207,7 +207,7 @@ class Translator {
         );
 
         // Tags included in translation strings when used in <p> or <li>
-        $ignoredTags = array('a', 'kbd', 'strong');
+        $ignoredTags = array('a', 'kbd', 'strong', 'em', 'code', 'sup', 'sub');
 
         // Begin parsing input HTML
         $i = 0;


### PR DESCRIPTION
Adds `<em>`, `<code>`, `<sup>` and `<sub>` to the list of ignored tags. This allows strings in `<p>` and `<li>` not to be split because of these tags.