### PR TITLE
Adds $sitewide['root'] in extract-l10n.php

### DIFF
--- a/backend/extract-l10n.php
+++ b/backend/extract-l10n.php
@@ -88,6 +88,8 @@ if ($isMarkdown) {
 } else {
 	chdir('..');
 
+	$sitewide['root'] = '/';
+
 	define('HTML_I18N', 1); // Do not start output buffering twice
 	ob_start(function ($input) use($l10n) {
 	    $l10n->translate_html($input, 'capture_translation');


### PR DESCRIPTION
This was breaking URL in footer when extracting translations (https://github.com/elementary/mvp/blob/master/_templates/footer.php#L7).