### PR TITLE
Nav height to min-height

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -207,7 +207,7 @@ img.hero {
 
 nav {
     width: 100%;
-    height: 56px;
+    min-height: 56px;
     line-height: 56px;
 }
 


### PR DESCRIPTION
Hotfix for #619

width of the navbar and the width at when it switches to scroll mode is hardcoded for English. This is a quick fix that just makes sure all links are shown on languages like Russian and German. It doesn't fully fix #619