### PR TITLE
Actually make the blog link internal, now it has internal navigation.

### DIFF
--- a/scripts/external-links.js
+++ b/scripts/external-links.js
@@ -1,7 +1,7 @@
 $(function () {
     $('a').not('[href*="mailto:"]').each(function () {
         var href = this.href;
-        if ( href.indexOf(window.location.host) != -1 ) {
+        if ( href.indexOf(window.location.host) == -1 ) {
             $(this).attr('target', '_blank');
         }
     });

--- a/scripts/external-links.js
+++ b/scripts/external-links.js
@@ -1,5 +1,5 @@
 $(function () {
-    $('a').not('[href*="mailto:"]').each(function () {{
+    $('a').not('[href*="mailto:"]').each(function () {
         var href = this.href;
         if ( href.indexOf(window.location.host) != -1 ) {
             $(this).attr('target', '_blank');

--- a/scripts/external-links.js
+++ b/scripts/external-links.js
@@ -1,8 +1,7 @@
 $(function () {
-    $('a').not('[href*="mailto:"]').each(function () {
-        var a = new RegExp('/' + window.location.host + '/');
+    $('a').not('[href*="mailto:"]').each(function () {{
         var href = this.href;
-        if ( ! a.test(href) ) {
+        if ( href.indexOf(window.location.host) != -1 ) {
             $(this).attr('target', '_blank');
         }
     });


### PR DESCRIPTION
On https://elementary.io/ the "Blog" link opens in a new tab.

On https://beta.elementary.io/branch/blog-internal/ the "Blog" link does not, as intended.