### PR TITLE
Stop subdomain links opening in new tab

### DIFF
--- a/scripts/external-links.js
+++ b/scripts/external-links.js
@@ -1,6 +1,6 @@
 $(function () {
     $('a').not('[href*="mailto:"]').each(function () {
-        var a = new RegExp('/' + window.location.host + '/');
+        var a = new RegExp(window.location.host);
         var href = this.href;
         if ( ! a.test(href) ) {
             $(this).attr('target', '_blank');


### PR DESCRIPTION
Fix regex matching. Stops blog.elementary.io opening in new tab.