### PR TITLE
Add tracking to download button click.

### DIFF
--- a/scripts/homepage.js
+++ b/scripts/homepage.js
@@ -40,6 +40,9 @@
         console.log('Pay ' + current_amount);
         var payment_amount = $('#' + current_amount).val() * 100;
         console.log('Starting payment for ' + payment_amount);
+        if (window.ga) {
+            ga('send', 'event', 'Freya Beta Download (Payment)', 'Homepage', payment_amount);
+        }
         if (payment_amount < payment_minimum) {
             open_download_overlay();
         } else {


### PR DESCRIPTION
This will mean we can compare how many people click to download with an amount selected vs. how many payments are actually made, so we know whether or not our form is actualy misleading, or if people are more intelligent than they are often given credit for.