### PR TITLE
Fix #668: Stripe still prompts for payment after having paid

### DIFF
--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@
                     <?php
                         if ( isset($_COOKIE['has_paid_freya']) && $_COOKIE['has_paid_freya'] ) {
                             ?>
-                    <input type="hidden" id="amount-twenty-five" value="0">
+                    <input type="hidden" id="amount-ten" value="0">
                             <?php
                         } else {
                             ?>


### PR DESCRIPTION
Fix #668: Stripe still prompts for payment after having paid

This is because of the move to 10 as a new default, making our zero-value non-default.

http://beta.elementary.io/branch/fix-668