### PR TITLE
Fixes an issue with DOCUMENT_ROOT in extract-l10n.php

### DIFF
--- a/backend/extract-l10n.php
+++ b/backend/extract-l10n.php
@@ -88,7 +88,7 @@ if ($isMarkdown) {
 } else {
 	chdir('..');
 
-	$sitewide['root'] = '/';
+	$_SERVER['DOCUMENT_ROOT'] = dirname(__DIR__);
 
 	define('HTML_I18N', 1); // Do not start output buffering twice
 	ob_start(function ($input) use($l10n) {


### PR DESCRIPTION
In `sitewide.php` the variable `$sitewide['root']` is generated from `$_SERVER['DOCUMENT_ROOT']`. When running a PHP script from the command line, `$_SERVER['DOCUMENT_ROOT']` is not defined and this results in a PHP notice being triggered and a wrong value for `$sitewide['root']`.