### PR TITLE
Adding a translation guide

### DIFF
--- a/docs/translation-guide.md
+++ b/docs/translation-guide.md
@@ -1,0 +1,16 @@
+# Translation guide {#translation-guide}
+
+We want elementary OS to reach as much people as possible, localization of our website and applications are very important for this. This is why we want to get as much people involved with translations as possible, to do this translations are open to anyone who wishes to contribute and require little to no technical knowledge about the internals of the operating system. Because we want to have a unified experience on the operating system there is a set of guidelines that must be met by translators to keep this experience through different languages, here you will find resources to start translating applications or our website.
+
+# Translating our applications {#translating-elementary-applications}
+
+Applications are translated through Rosetta which is Launchpad's translation interface, for this you need to have a [Launchpad](https://launchpad.net/) account and be logged in. Then you can browse all [translation projects](https://translations.launchpad.net/elementary) for elementary applications. After choosing the one you want and the language you are going to translate to, you can make suggestion for strings that currently have not been translated, or suggest changes to strings that already have a translation. This suggestions will be evaluated by one of the translation team members and they will choose the most appropriate one from all of them. For a more in depth introduction to Rosetta's interface you can refer to their [documentation](https://help.launchpad.net/Translations/StartingToTranslate).
+
+While translating you may get in a situation where you have to decide between several ways of saying the same thing, for this situations we follow the Ubuntu [general translator guide](https://help.launchpad.net/Translations/Guide), and for language specific issues we follow Ubuntu's [team translation guidelines](https://translations.launchpad.net/+groups/ubuntu-translators). Following this guides helps us have uniform translations, while at the same time allowing anyone to contribute.
+
+# Translating our website {#translating-our-website}
+
+To ease the translation of our website we use [Transifex](https://www.transifex.com/projects/p/elementary-mvp/), this allows us to put all text that needs  to be translated in one place that is open to anyone who speaks another language. To start translating, you first need to register, then look for elementary as an organization add yourself as a translator, you can follow [Transifex's documentation](http://docs.transifex.com/tutorials/txeditor) for this.
+
+As before we try to follow Ubuntu's translation guidelines with one difference, we try to take a friendly approach to welcome new users and express a closer relationship to welcome new users to our community.
+


### PR DESCRIPTION
The idea is to add more information than the currently available through the translation section on the "get involved" page such as: links to used translation guidelines (general and language specific) and documentation about the web interfaces for Rosetta and Transifex.

I've seen most distributions only translate the operating system and not the website,  these may be different, here we could specify these differences.

I'm still not sure about saying who to contact, in order to become a member of a translation team or a reviewer.