### PR TITLE
use example.com instead of domain.com in GPL header

### DIFF
--- a/docs/code/reference.md
+++ b/docs/code/reference.md
@@ -176,7 +176,7 @@ limit is 120 characters.
     * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
     * Boston, MA 02111-1307, USA.
     *
-    * Authored by: Author <mail@domain.com>
+    * Authored by: Author <author@example.com>
     */
 
 # Reporting Bugs {#reporting-bugs}


### PR DESCRIPTION
See: https://tools.ietf.org/html/rfc2606#section-3