### PR TITLE
Add a warning to all pages when not explicitly running in production (Fixes #780)

### DIFF
--- a/_templates/header.php
+++ b/_templates/header.php
@@ -140,7 +140,7 @@ $l10n->begin_html_translation();
                     <i class="warning fa fa-warning"></i>
                 </div>
                 <div class="icon-text">
-                    <h2 id="back-up-your-data">Warning: Development Site</h2>
+                    <h3>Warning: Development Site</h3>
                     <p>You are viewing a development version of our site. Some pages here may not work or act as you expect. If you got here by accident please go to <a href="http://elementary.io">elementary.io</a>, our actual website address.</p>
                 </div>
             </div>

--- a/_templates/header.php
+++ b/_templates/header.php
@@ -133,5 +133,15 @@ $l10n->begin_html_translation();
         </nav>
 
         <div id="content-container">
+<?php if (!isset($_ENV['PHPENV']) || $_ENV['PHPENV'] !== "production" ): ?>
+        <div class="row">
+            <div class="dev-alert">
+                <p><strong>Be warned, you are viewing a development version of our site</strong></p>
+                <p>Some pages here may not work or act as you expect.</p>
+                <br>
+                <p>If you got here by accident please go to <a href="http://elementary.io">elementary.io</a>, our actual website address.</p>
+            </div>
+        </div>
+<?php endif; ?>
 <?php
 $l10n->set_domain($page['name']);

--- a/_templates/header.php
+++ b/_templates/header.php
@@ -134,12 +134,15 @@ $l10n->begin_html_translation();
 
         <div id="content-container">
 <?php if (!isset($_ENV['PHPENV']) || $_ENV['PHPENV'] !== "production" ): ?>
-        <div class="row">
-            <div class="dev-alert">
-                <p><strong>Be warned, you are viewing a development version of our site</strong></p>
-                <p>Some pages here may not work or act as you expect.</p>
-                <br>
-                <p>If you got here by accident please go to <a href="http://elementary.io">elementary.io</a>, our actual website address.</p>
+        <div class="row alert warning">
+            <div class="column alert">
+                <div class="icon">
+                    <i class="warning fa fa-warning"></i>
+                </div>
+                <div class="icon-text">
+                    <h2 id="back-up-your-data">Warning: Development Site</h2>
+                    <p>You are viewing a development version of our site. Some pages here may not work or act as you expect. If you got here by accident please go to <a href="http://elementary.io">elementary.io</a>, our actual website address.</p>
+                </div>
             </div>
         </div>
 <?php endif; ?>

--- a/_templates/header.php
+++ b/_templates/header.php
@@ -140,7 +140,7 @@ $l10n->begin_html_translation();
                     <i class="warning fa fa-warning"></i>
                 </div>
                 <div class="icon-text">
-                    <h3>Warning: Development Site</h3>
+                    <h3>This is a development site.</h3>
                     <p>You are viewing a development version of our site. Some pages here may not work or act as you expect. If you got here by accident please go to <a href="http://elementary.io">elementary.io</a>, our actual website address.</p>
                 </div>
             </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -515,6 +515,16 @@ footer ul li a:focus {
     margin: 8px 0 0;
 }
 
+.dev-alert {
+    padding: 9px;
+    background: #FFE946;
+    border: 2px dotted black;
+}
+
+.dev-alert p {
+    color: black;
+}
+
 .icon {
     position: relative;
     text-align: center;

--- a/styles/main.css
+++ b/styles/main.css
@@ -515,16 +515,6 @@ footer ul li a:focus {
     margin: 8px 0 0;
 }
 
-.dev-alert {
-    padding: 9px;
-    background: #FFE946;
-    border: 2px dotted black;
-}
-
-.dev-alert p {
-    color: black;
-}
-
 .icon {
     position: relative;
     text-align: center;


### PR DESCRIPTION
The warning is controlled by a ENV variable called PHPENV.
Accepted values are: dev, staging, production

This fixes #780.