### PR TITLE
Don't replace location.hash on every scroll

### DIFF
--- a/scripts/docs/main.js
+++ b/scripts/docs/main.js
@@ -60,7 +60,9 @@ $(document).ready(function() {
     // Url hash selector. Only in docs class to avoid nav conflicts
     $(document).on('scroll', function (event) {
         // Changes browser hash without adding to history
-        history.replaceState(undefined, undefined, location.href.split("#")[0]+"#"+currentSection.id);
+        if (currentSection.id !== location.hash.substr(1)) {
+            history.replaceState(undefined, undefined, location.href.split("#")[0]+"#"+currentSection.id);
+        }
     });
 
     // Sidebar


### PR DESCRIPTION
Don't replace location.hash on every scroll; not only is this inelegant, but when you replaceState some browsers, including Chrome, re-request favicon.ico. Instead, only replace when it's actually required to, so we don't hit favicon.ico on every scroll.