### PR TITLE
Fix Issue #1112 : Make a note in the code style guide about translato…

### DIFF
--- a/docs/code/reference.md
+++ b/docs/code/reference.md
@@ -117,6 +117,8 @@ than good.
         l = n * 2 + 4;   // Clear l variable
     }
 
+For translators' comments, use triple forward slash `///`.
+
 ## Variable names, class names, function names {#variable-names-class-names-function-names}
 
 

--- a/docs/code/reference.md
+++ b/docs/code/reference.md
@@ -118,6 +118,11 @@ than good.
     }
 
 For translators' comments, use triple forward slash `///`.
+```
+{
+    "elementary OS": false /// Can't be translated
+}
+```
 
 ## Variable names, class names, function names {#variable-names-class-names-function-names}
 


### PR DESCRIPTION
Fixes #1112 

Added a note to use `///` for translators' comments.

This pull request  is ready for review.

 Found out about this issue at 'Up For Grabs'.