### PR TITLE
use js to calculate doc sidebar position

### DIFF
--- a/scripts/docs/main.js
+++ b/scripts/docs/main.js
@@ -82,6 +82,29 @@ $(document).ready(function() {
         currentSection = docElements[0];
     };
 
+    // Makes sidebar sticky with footer and header
+    function sidebarHandle() {
+        if ($(window).width() <= 990) return
+
+        var scrollTop = $(this).scrollTop();
+        var $header = $('nav:first-of-type')
+        var $footer = $('footer')
+        var $sidebar = $('.sidebar')
+
+        var headerFromTop = $header.height() - scrollTop
+        var headerSquish = (headerFromTop > 0) ? headerFromTop : 0
+        if (headerSquish === 0) {
+          $sidebar.addClass('sticky')
+        } else {
+          $sidebar.removeClass('sticky')
+        }
+
+        var footerFromBottom = $(document).height() - $(window).height() - $footer.height() - scrollTop
+        var footerSquish = (footerFromBottom < 0) ? Math.abs(footerFromBottom) : 0
+
+        $sidebar.css('height', "calc(100% - " + footerSquish + "px - " + headerSquish + "px)")
+    }
+
     // Scrolling function to run
     function scrollHandle() {
         // Check to see what is on screen right now
@@ -116,25 +139,6 @@ $(document).ready(function() {
         } else {
           ($currentLink.parent().parent().prev('li').addClass('active'));
         };
-
-        // Makes sidebar sticky with footer and header
-        var scrollTop = $(this).scrollTop();
-        var $header = $('nav:first-of-type')
-        var $footer = $('footer')
-        var $sidebar = $('.sidebar')
-
-        var headerFromTop = $header.height() - scrollTop
-        var headerPeak = (headerFromTop > 0) ? headerFromTop : 0
-        $sidebar.css('margin-top', headerPeak - $header.height())
-        $sidebar.css('padding-bottom', headerPeak)
-
-
-        var footerFromBottom = $(document).height() - $(window).height() - $footer.height() - scrollTop
-        var footerPeak = (footerFromBottom < 0) ? Math.abs(footerFromBottom) : 0
-
-        console.log(footerFromBottom, footerPeak)
-
-        $sidebar.css('height', "calc(100% - " + footerPeak + "px)")
     }
 
     // Scroll timeout handling
@@ -142,27 +146,25 @@ $(document).ready(function() {
     var repositionTimer = null
 
     $(window).scroll(function () {
+        if ($(window).width() <= 990) return
+
         var diff = new Date().getTime() - repositionedAt;
 
         var scrollTop = $(this).scrollTop();
         var scrollBottom = ($(document).height() - (scrollTop + $(window).height()));
 
-        var diffTime = 300
+        sidebarHandle();
 
-        if (scrollTop < 1000 || scrollBottom < 1000) {
-          diffTime = 100
-        }
-
-        if ( repositionedAt == null || diff >= diffTime ) {
-            console.log('Called bc Diff');
+        if ( repositionedAt == null || diff >= 500 ) {
             repositionedAt = new Date().getTime();
             scrollHandle();
         } else { // Wait until scroll spam stops
             clearTimeout(repositionTimer);
-            repositionTimer = setTimeout(scrollHandle, diffTime);
+            repositionTimer = setTimeout(scrollHandle, 500);
         }
     });
 
     // Run scrolling function at first load
+    sidebarHandle();
     scrollHandle();
 });

--- a/scripts/docs/main.js
+++ b/scripts/docs/main.js
@@ -108,11 +108,7 @@ $(document).ready(function() {
             history.replaceState(undefined, undefined, location.href.split("#")[0]+"#"+currentSection.id);
         }
 
-        var scrollTop = $(this).scrollTop();
-
-        $sidebar.toggleClass('nav-visible', (scrollTop < navHeight));
-        $sidebar.toggleClass('footer-visible', (scrollTop + $(window).height() > footerScrollTop));
-
+        // Changes sidebar link classes based on what's currently active
         $('.sidebar .index .active').removeClass('active');
         var $currentLink = $('.sidebar .index a[href$="#'+currentSection.id+'"]')
         if ($currentLink.parent().parent().is('.index')) {
@@ -120,6 +116,25 @@ $(document).ready(function() {
         } else {
           ($currentLink.parent().parent().prev('li').addClass('active'));
         };
+
+        // Makes sidebar sticky with footer and header
+        var scrollTop = $(this).scrollTop();
+        var $header = $('nav:first-of-type')
+        var $footer = $('footer')
+        var $sidebar = $('.sidebar')
+
+        var headerFromTop = $header.height() - scrollTop
+        var headerPeak = (headerFromTop > 0) ? headerFromTop : 0
+        $sidebar.css('margin-top', headerPeak - $header.height())
+        $sidebar.css('padding-bottom', headerPeak)
+
+
+        var footerFromBottom = $(document).height() - $(window).height() - $footer.height() - scrollTop
+        var footerPeak = (footerFromBottom < 0) ? Math.abs(footerFromBottom) : 0
+
+        console.log(footerFromBottom, footerPeak)
+
+        $sidebar.css('height', "calc(100% - " + footerPeak + "px)")
     }
 
     // Scroll timeout handling
@@ -129,11 +144,22 @@ $(document).ready(function() {
     $(window).scroll(function () {
         var diff = new Date().getTime() - repositionedAt;
 
-        if ( repositionedAt == null || diff >= 10 ) {
-            clearTimeout(repositionTimer);
+        var scrollTop = $(this).scrollTop();
+        var scrollBottom = ($(document).height() - (scrollTop + $(window).height()));
+
+        var diffTime = 300
+
+        if (scrollTop < 1000 || scrollBottom < 1000) {
+          diffTime = 100
+        }
+
+        if ( repositionedAt == null || diff >= diffTime ) {
             console.log('Called bc Diff');
             repositionedAt = new Date().getTime();
-            repositionTimer = setTimeout(scrollHandle, 0);
+            scrollHandle();
+        } else { // Wait until scroll spam stops
+            clearTimeout(repositionTimer);
+            repositionTimer = setTimeout(scrollHandle, diffTime);
         }
     });
 

--- a/styles/docs.css
+++ b/styles/docs.css
@@ -184,11 +184,17 @@ nav {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
-    height: 100%;
+    height: calc(100% - 56px);
     list-style-type: none;
     overflow: auto;
-    position: fixed;
+    position: absolute;
     width: 300px;
+}
+
+.sidebar.sticky {
+  left: 0;
+  position: fixed;
+  top: 0;
 }
 
 .sidebar a {

--- a/styles/docs.css
+++ b/styles/docs.css
@@ -186,22 +186,9 @@ nav {
     flex-direction: column;
     height: 100%;
     list-style-type: none;
-    margin-top: -56px;
     overflow: auto;
     position: fixed;
-    transition: all 0.15s ease-in-out;
     width: 300px;
-}
-
-.sidebar.nav-visible {
-    margin-top: 0;
-    padding-bottom: 56px;
-}
-
-.sidebar.footer-visible {
-    border-bottom: 1px solid #f0f0f0;
-    border-bottom-right-radius: 3px;
-    height: calc(100% - 42px);
 }
 
 .sidebar a {


### PR DESCRIPTION
Fixes #1136 

### Changes Summary

Uses javascript to calculate position of sidebar. This makes the sidebar fit better, instead of the all or none css styles we had. It still seems janky to me a bit when scrolling (especially at the header), so at some point I will probably rewrite the doc js file.

