### PR TITLE
Update download button text on #amount-custom blur

### DIFF
--- a/scripts/homepage.js
+++ b/scripts/homepage.js
@@ -29,6 +29,8 @@ $(function () {
             current_amount = previous_amount;
             // Set the old amount as checked.
             $('#' + current_amount).addClass('checked');
+
+            updateDownloadButton();
         }
     };
     // Listen for Clicking on Amounts


### PR DESCRIPTION
In the homepage, the download button text is not updated correctly when the value of "#amount-custom" is [not valid or empty](https://github.com/elementary/mvp/blob/fd0763fb9669d2887406e70c8d3f950360ef806b/scripts/homepage.js#L22-L25) and the element [loses focus](https://github.com/elementary/mvp/blob/fd0763fb9669d2887406e70c8d3f950360ef806b/scripts/homepage.js#L37).

**Reproducible steps**:

1) Click on any of the amount button (e.g. $25 a.k.a "#amount-twenty-five")
2) Focus on the custom amount input field (a.k.a "#amount-custom")
3) Move focus out of the custom amount input field

**Expected result**: the download button text should be "Purchase elementary OS".
**Actual result**: the download button text is "Download elementary OS".