### PR TITLE
Prevent the browser from caching the chart data for more than one day

### DIFF
--- a/scripts/get-involved.js
+++ b/scripts/get-involved.js
@@ -1,6 +1,8 @@
 $(function () {
+    var dateYearMonthDay = new Date().toISOString().substring(0, 10);
+    var preventingCacheSuffix = '?' + dateYearMonthDay;
     $.ajax({
-        url: 'backend/chart.json',
+        url: 'backend/chart.json' + preventingCacheSuffix,
         dataType: 'json'
     }).done(function (data) {
         var labels = {


### PR DESCRIPTION
Fixes #1185 (duplicate of #1131)

### Changes Summary

- Create a suffix in the form of YYYY-MM-DD
- Append the suffix to the chart.json url in the ajax request

This pull request is ready for review.
