### PR TITLE
Notifications Doc: Removed LOW priority functionality

### DIFF
--- a/docs/code/getting-started.md
+++ b/docs/code/getting-started.md
@@ -787,7 +787,7 @@ Notifications also have priority. When a notification is set as `URGENT` it will
 
 	notification.set_priority (NotificationPriority.URGENT);
 
-`URGENT` notifications should really only be used on the most extreme cases. There are also [other notification priorities](http://valadoc.elementary.io/#!api=gio-2.0/GLib.NotificationPriority); Notifications with `LOW` priority, for example, are skipped from the notifications indicator.
+`URGENT` notifications should really only be used on the most extreme cases. There are also [other notification priorities](http://valadoc.elementary.io/#!api=gio-2.0/GLib.NotificationPriority);
 
 ## Review {#notifications-review}
 Let's review what all we've learned:

--- a/docs/code/getting-started.md
+++ b/docs/code/getting-started.md
@@ -787,7 +787,7 @@ Notifications also have priority. When a notification is set as `URGENT` it will
 
 	notification.set_priority (NotificationPriority.URGENT);
 
-`URGENT` notifications should really only be used on the most extreme cases. There are also [other notification priorities](http://valadoc.elementary.io/#!api=gio-2.0/GLib.NotificationPriority);
+`URGENT` notifications should really only be used on the most extreme cases. There are also [other notification priorities](http://valadoc.elementary.io/#!api=gio-2.0/GLib.NotificationPriority).
 
 ## Review {#notifications-review}
 Let's review what all we've learned:


### PR DESCRIPTION
LOW Priority apparently never got the notifications from being skipped from the notifications indicator. I must have made that up at some point :(