### PR TITLE
move button margin to main.css to affect all modals

### DIFF
--- a/styles/developer.css
+++ b/styles/developer.css
@@ -114,9 +114,7 @@ footer,
 }
 
 .modal .row.actions .column {
-    margin: 6px;
     width: 200px;
-    margin: 6px !important;
 }
 
 .modal .row.actions .column:first-of-type a {

--- a/styles/main.css
+++ b/styles/main.css
@@ -917,8 +917,8 @@ input:focus:-ms-input-placeholder {
     padding: 0;
 }
 
-.modal .row.actions .linked {
-    margin: 6px;
+.modal .row.actions .column {
+    margin: 6px !important;
 }
 
 i.fa.fa-close.close-modal {


### PR DESCRIPTION
Fixes modal button alignment

### Changes Summary

- The buttons in modals when wrapped are getting weird margins. This fixes them so they are aligned