### PR TITLE
Fix odd issue where `getenv` is set but `$_ENV` isn't.

### DIFF
--- a/_templates/alert.php
+++ b/_templates/alert.php
@@ -1,6 +1,6 @@
 <?php
 $l10n->set_domain('layout');
-if (!isset($_ENV['PHPENV']) || $_ENV['PHPENV'] !== "production" ):
+if (!isset(getenv('PHPENV')) || getenv('PHPENV') !== 'production' ):
 ?>
         <div class="row alert warning">
             <div class="column alert">


### PR DESCRIPTION
### Changes Summary

- Replace `$_ENV` with `getenv`

This pull request is ready for review.

