### PR TITLE
Validate custom amount in browsers that does n't support number type.

### DIFF
--- a/scripts/homepage.js
+++ b/scripts/homepage.js
@@ -33,10 +33,27 @@ $(function () {
             updateDownloadButton();
         }
     };
+    var amountValidate = function(event) {
+      
+      var currentVal = $('#amount-custom').val();
+      
+      var code = event.which | event.keyCode | event.charCode;
+      var specialKeys = [8, 37, 39];
+      
+      if ((code != 46 || currentVal.indexOf('.') != -1) && 
+          specialKeys.indexOf(code) == -1 && 
+          (code < 48 || code > 57)) {
+          event.preventDefault();
+      }
+    }
+      
+    
     // Listen for Clicking on Amounts
     $('.target-amount').click(amountClick);
     // Check Custom Amounts on Blur
     $('#amount-custom').blur(amountBlur);
+    // Don't allow non-digit input
+    $('#amount-custom').keypress(amountValidate);
 
     $('#download').click(function(){
         console.log('Pay ' + current_amount);


### PR DESCRIPTION
Fixes #1192 

### Changes Summary

- Check each character that is being entered to input field. If it anything other than arrow keys, delete, backspace, ., or digit prevent default action.

### Known issue.

- Consequent decimal points as in `1..` can't be validated. Because, when value in input field is `1.`, `.val()` method returns just `.`.

This pull request is ready for review.

