### PR TITLE
Don't use pager in non-interactive tests.

### DIFF
--- a/_tests/css.sh
+++ b/_tests/css.sh
@@ -13,7 +13,7 @@ npm install csscomb
 ./node_modules/.bin/csscomb styles/*.css
 
 if ! git diff --quiet styles/; then
-    git diff styles/
+    git --no-pager diff styles/
 
     echo "##############################################################"
     echo "CSS linting detected an error. Please use csscomb and resubmit"


### PR DESCRIPTION
### Changes Summary

- Using the pager in the non-interactive tests causes it to hang.

This pull request is ready for review.

