### PR TITLE
fix incorrect coloring for .third a

### DIFF
--- a/developer.php
+++ b/developer.php
@@ -30,21 +30,21 @@
 <?php include $template['alert']; ?>
 
 <section class="grid">
-    <div class="third"><a href="docs/code/getting-started">
+    <a class="third" href="docs/code/getting-started">
         <i class="fa fa-book"></i>
         <h3>Documentation</h3>
         <p>Get a basic app running, built, and ready for distribution with our Getting Started guide.</p>
-    </a></div>
-    <div class="third"><a href="docs/human-interface-guidelines">
+    </a>
+    <a class="third" href="docs/human-interface-guidelines">
         <i class="fa fa-pencil"></i>
         <h3>Design</h3>
         <p>Learn about the design principles that make up apps on elementary OS.</p>
-    </a></div>
-    <div class="third"><a href="docs/code/reference">
+    </a>
+    <a class="third" href="docs/code/reference">
         <i class="fa  fa-code"></i>
         <h3>Reference</h3>
         <p>Get more info about code style, reporting issues, and proposing design changes.</p>
-    </a></div>
+    </a>
 </section>
 <div class="grid">
     <hr/>

--- a/styles/main.css
+++ b/styles/main.css
@@ -538,11 +538,11 @@ footer ul li a:focus {
     text-align: center;
 }
 
-.third a {
+a.third {
     color: inherit;
 }
 
-.third a:hover {
+a.third:hover {
     color: #08C;
     fill: #08C;
 }

--- a/styles/open-source.css
+++ b/styles/open-source.css
@@ -18,6 +18,14 @@
     vertical-align: top;
 }
 
+.platform-item a {
+    color: inherit;
+}
+
+.platform-item a:hover {
+    color: #08c;
+}
+
 hr.dotted {
     background: transparent;
     border-top: 1px dashed #c9c9c9;


### PR DESCRIPTION
Set color inherit for a.third instead of .third a. This allows for normal text color when the whole section is a link and doesn't break "learn more" links when it's not.

