### PR TITLE
use padding vs margin for grid cells

### DIFF
--- a/_styles/main.css
+++ b/_styles/main.css
@@ -473,8 +473,10 @@ footer ul li a:focus {
     width: auto;
 }
 
-.grid > * {
-    margin: 16px;
+.grid .half,
+.grid .third,
+.grid .two-thirds {
+    padding: 16px;
 }
 
 .grid .grid {
@@ -485,7 +487,7 @@ footer ul li a:focus {
     .grid .half {
         display: inline-block;
         vertical-align: top;
-        width: calc(50% - 48px);
+        width: 49%;
     }
 
     .grid .half h2 {
@@ -493,21 +495,15 @@ footer ul li a:focus {
     }
 
     .grid .third {
-        width: calc(33.33% - 32px);
+        width: 33%;
         display: inline-block;
         vertical-align: top;
-        margin-right: 16px;
-    }
-
-    .grid .third:last-child {
-        margin-left: 16px;
-        margin-right: 0;
     }
 
     .grid .two-thirds {
         display: inline-block;
         vertical-align: top;
-        width: calc(66% - 48px);
+        width: 66%;
     }
 
     .grid *:only-child p {


### PR DESCRIPTION
Using `margin` for grids is a mess. Not only do you have to calculate width, but you have to account for mixed cells like a `half` + `third`. This switches the margin to use `padding` instead.

Fixes
- removing margin on `third` element when there is a header (`homepage`  "What the press is saying about elementary OS" section)