### PR TITLE
make the countdown a bit more responsive

### DIFF
--- a/_styles/countdown.css
+++ b/_styles/countdown.css
@@ -21,6 +21,7 @@
 .countdown-wrapper {
     overflow: auto;
     padding: 16px;
+    width: 100%;
     text-align: center;
     user-select: none;
 }
@@ -311,6 +312,10 @@
     100% {
         opacity: 0;
     }
+}
+
+.countdown-wrapper .read-more {
+    padding: 30px;
 }
 
 @media (min-width: 800px) {

--- a/_styles/countdown.css
+++ b/_styles/countdown.css
@@ -3,26 +3,31 @@
 * This file is part of elementary.io *
 *************************************/
 
-.countdown-wrapper {
-    -webkit-user-select: none;
+.countdown-background {
     align-items: center;
     backdrop-filter: blur(10px);
     background-color: rgba(255, 255, 255, 0.95);
+    bottom: 0;
     display: flex;
     flex-direction: column;
-    height: 100vh;
     justify-content: center;
     left: 0;
-    padding: 16px;
     position: fixed;
+    right: 0;
     top: 0;
-    width: 100%;
     z-index: 999;
+}
+
+.countdown-wrapper {
+    overflow: auto;
+    padding: 16px;
+    text-align: center;
+    user-select: none;
 }
 
 .flip-clock-wrapper {
     animation: show 2s ease-in forwards;
-    margin: 128px 16px;
+    margin: 10px 16px;
     opacity: 0;
 }
 
@@ -58,6 +63,14 @@
     *zoom: 1;
 }
 
+/* Flip Pair Wrapper (EDITED FROM FLIPCLOCK.JS) */
+
+.flip-wrapper {
+    position: relative;
+    margin: 20px 0;
+    padding-top: 30px;
+}
+
 /* Main */
 
 .flip-clock-meridium {
@@ -78,15 +91,15 @@
 
 /* Skeleton */
 .flip-clock-wrapper ul {
-    position: relative;
-    float: left;
-    margin: 5px;
-    width: 60px;
-    height: 90px;
-    font-weight: bold;
-    line-height: 87px;
-    border-radius: 6px;
     background: #3689e6;
+    border-radius: 6px;
+    display: inline-block;
+    font-weight: bold;
+    height: 90px;
+    line-height: 87px;
+    margin: 5px;
+    position: relative;
+    width: 60px;
 }
 
 .flip-clock-wrapper ul li {
@@ -191,47 +204,19 @@
 }
 
 .flip-clock-divider {
-    float: left;
-    display: inline-block;
-    position: relative;
-    width: 20px;
-    height: 100px;
-}
-
-.flip-clock-divider:first-child {
-    width: 0;
-}
-
-.flip-clock-dot {
-    display: block;
-    background: #2b63a0;
-    width: 6px;
-    height: 6px;
+    bottom: 0;
+    left: 0;
     position: absolute;
-    border-radius: 50%;
-    left: 8px;
+    right: 0;
+    top: 0;
 }
 
 .flip-clock-divider .flip-clock-label {
+    left: 0;
     position: absolute;
-    top: -24px;
-    right: -86px;
-}
-
-.flip-clock-divider.minutes .flip-clock-label {
-    right: -88px;
-}
-
-.flip-clock-divider.seconds .flip-clock-label {
-    right: -91px;
-}
-
-.flip-clock-dot.top {
-    top: 30px;
-}
-
-.flip-clock-dot.bottom {
-    bottom: 30px;
+    text-align: center;
+    top: 0;
+    width: 100%;
 }
 
 @keyframes asd {
@@ -325,5 +310,37 @@
 
     100% {
         opacity: 0;
+    }
+}
+
+@media (min-width: 800px) {
+    .flip-wrapper {
+        display: inline-block;
+    }
+
+    .flip-wrapper:not(:first-of-type) {
+        padding-left: 26px;
+    }
+
+    .flip-wrapper:not(:first-of-type) .flip-clock-divider .flip-clock-label {
+        padding-left: 26px;
+    }
+
+    .flip-clock-dot {
+        background: #2b63a0;
+        border-radius: 50%;
+        display: block;
+        height: 6px;
+        left: 10px;
+        position: absolute;
+        width: 6px;
+    }
+
+    .flip-clock-dot.top {
+        top: 60px;
+    }
+
+    .flip-clock-dot.bottom {
+        bottom: 30px;
     }
 }

--- a/_templates/countdown.php
+++ b/_templates/countdown.php
@@ -11,23 +11,50 @@ if (
 
 ?>
 
-<div class="countdown-wrapper">
-    <div class="countdown"></div>
-    <a class="read-more" href="#">Continue</a>
+<div class="countdown-background">
+    <div class="countdown-wrapper">
+        <div class="countdown"></div>
+        <a class="read-more" href="#">Continue</a>
+    </div>
 </div>
 
 <link rel="stylesheet" type="text/css" media="all" href="styles/countdown.css">
 <script>
     $('document').ready(function () {
+        FlipClock.MvpClockFace = FlipClock.DailyCounterFace.extend({
+            showSeconds: true,
+            build: function (time) {
+                var t = this
+    			var $el = this.factory.$el
+    			var offset = 0
+
+    			time = time ? time : this.factory.time.getDayCounter(this.showSeconds)
+
+    			if (time.length > $el.children('ul').length) {
+    				$.each(time, function (i, digit) {
+    					t.createList(digit)
+    				})
+    			}
+
+                var children = $el.children('ul')
+
+                for (var i = 0; i < children.length; i += 2) {
+                    children.slice(i, i + 2).wrapAll('<div class="flip-wrapper"></div>')
+                }
+
+                this.base()
+            }
+        })
+
         var releaseDate = new Date('<?php echo date('D M d Y H:i:s O', date_timestamp_get($releaseDate)) ?>')
 
         var clock = $('.countdown').FlipClock(releaseDate, {
-            clockFace: 'DailyCounter',
+            clockFace: 'MvpClock',
             countdown: true
         })
 
         $('.read-more').click(function () {
-            $('.countdown-wrapper').hide()
+            $('.countdown-background').hide()
             var expireDate = new Date()
             expireDate.setDate(expireDate.getDate() + 1)
             document.cookie = 'countdown=false; expires=' + expireDate.toUTCString()


### PR DESCRIPTION
This makes the countdown a bit more responsive by collapsing at widths smaller than 800px.

Why is this a PR?
Because we are close to pushing the countdown branch and I didn't want to break anything before release. This does edit the normal flipclock.js DOM, which (from what I could find) is not supported, so this needs some testing just in case.