### PR TITLE
Fix #1323: Website suggests download OS if value of custom amount is empty

### DIFF
--- a/scripts/download.js
+++ b/scripts/download.js
@@ -67,7 +67,8 @@ $(function () {
         // Catch case where a button is checked or the custom input is above the minimum.
         } else if (
             $('button.payment-button').hasClass('checked') ||
-            $('#amount-custom').val() * 100 >= paymentMinimum
+            $('#amount-custom').val() * 100 >= paymentMinimum ||
+            $('#amount-custom').val() === ''
         ) {
             $('#download').text(translatePurchase)
             document.title = translatePurchase


### PR DESCRIPTION
Fixes #1323: Website suggests download OS if value of custom amount is empty

### Changes Summary

- Add check for no entry in `#amount-custom`

This pull request is ready for review.